### PR TITLE
feat: standardize builder UI with CourseCard and shadcn primitives

### DIFF
--- a/docs/IMPLEMENTATION_SHADCN.md
+++ b/docs/IMPLEMENTATION_SHADCN.md
@@ -6,7 +6,7 @@
 
 **Timeline:** 3 Days.
 
-**Last Updated:** 2025-01-16
+**Last Updated:** 2025-01-16 (PR-S2 Completed)
 
 ---
 
@@ -122,25 +122,153 @@ _Goal: Replace the manual "Flexbox Sidebar" with the responsive, accessible `Sid
 
 ---
 
-## 🗓️ Phase 2: The Builder & Layouts (Day 2)
+## 🗓️ Phase 2: The Builder & Layouts (Day 2) ✅ COMPLETED
 
 _Goal: Remove raw `div` scrolling and borders. Use `Card` and `ScrollArea` to manage screen real estate._
 
-### 1. Refactor `CourseCard.tsx`
+### 1. Create `src/components/common/CourseCard.tsx` ✅
 
-- **Current:** `div` with border classes.
-- **New:** `<Card>`
-  - Title/Image → `<CardHeader>`
-  - Metadata badges → `<CardContent>` (Use `<Badge variant="secondary">`)
-  - Add Button → `<CardFooter>`
-- **Polish:** This instantly standardizes padding, shadows, and borders across the app.
+- [x] **Standardized card component for course display:**
+  - Props: `course: Course`, `action: "add" | "remove"`, `onAction: () => void`, `onClick?: () => void`
+  - Reusable across workbench and catalog views
+- [x] **Component Structure:**
 
-### 2. Refactor `ProgramBuilder.tsx` (The 2-Column Layout)
+  ```tsx
+  <Card className="cursor-pointer hover:bg-accent/50 transition-colors">
+    <CardHeader>
+      {/* Image thumbnail (w-16 h-16, 3:2 ratio if available) */}
+      <img src={course.previewImageUrl} />
 
-- **The Container:** Keep the Flexbox/Grid for the split (it works).
-- **The Columns:** Replace `overflow-y-auto` divs with `<ScrollArea className="h-[calc(100vh-theme(spacing.32))]">`.
-  - _Why:_ Shadcn's ScrollArea looks distinct (thinner bars) and handles cross-browser styling better.
-- **Inputs:** Replace standard `<input>` with `<Input />` and `<Textarea />`. This gives you consistent focus rings (Phillips Blue).
+      {/* Title + Level Badge */}
+      <h3>{course.courseTitle}</h3>
+      <Badge variant={course.levelName === "Advanced" ? "default" : "secondary"}>
+        {course.levelName}
+      </Badge>
+    </CardHeader>
+
+    <CardContent>
+      {/* Training Type, Duration (ILT=days, eLearning=hours), Course ID */}
+      <div>Type: {course.trainingTypeName}</div>
+      <div>Duration: {course.totalDays || course.hours}</div>
+      <div>ID: #{course.courseId}</div>
+    </CardContent>
+
+    <CardFooter>
+      <Button
+        variant={action === "remove" ? "destructive" : "outline"}
+        onClick={handleActionClick}
+      >
+        {action === "remove" ? "Remove" : "Add"}
+      </Button>
+    </CardFooter>
+  </Card>
+  ```
+
+### 2. Refactor `ProgramBuilder.tsx` (The 2-Column Layout) ✅
+
+- [x] **Inputs upgraded to shadcn components:**
+
+  ```tsx
+  // Program Title
+  <Input
+    value={programTitle}
+    onChange={...}
+    className="text-xl font-semibold border-none shadow-none focus-visible:ring-0 px-0"
+  />
+
+  // Program Description
+  <Textarea
+    value={programDescription}
+    onChange={...}
+    className="text-sm resize-none border-none shadow-none focus-visible:ring-0 px-0"
+  />
+
+  // Search Input
+  <Input
+    placeholder="Search courses..."
+    value={searchQuery}
+    onChange={...}
+    disabled={isLoading}
+  />
+  ```
+
+- [x] **Filter buttons use Button component:**
+
+  ```tsx
+  <Button
+    variant={activeFilters[filterKey] ? "secondary" : "ghost"}
+    size="sm"
+    className="flex-1"
+    onClick={() => toggleFilter(filterKey)}
+  >
+    {filterKey}
+  </Button>
+  ```
+
+- [x] **ScrollArea replaces raw overflow-y-auto:**
+
+  ```tsx
+  <ScrollArea className="flex-1">
+    <div className="p-4 space-y-3">{/* Course cards go here */}</div>
+  </ScrollArea>
+  ```
+
+- [x] **Course lists now use CourseCard:**
+
+  ```tsx
+  // Workbench (left column - sortable)
+  <SortableContext items={selectedCourses.map(c => c.id)} strategy={verticalListSortingStrategy}>
+    <div className="space-y-3">
+      {selectedCourses.map(course => (
+        <SortableCourseItem key={course.id} id={course.id}>
+          <CourseCard
+            course={course}
+            action="remove"
+            onAction={() => removeCourse(course.id)}
+            onClick={() => setActiveCourse(course)}
+          />
+        </SortableCourseItem>
+      ))}
+    </div>
+  </SortableContext>
+
+  // Catalog (right column - scrollable)
+  <ScrollArea className="flex-1">
+    <div className="p-4 space-y-3">
+      {filteredCourses.map(course => (
+        <CourseCard
+          key={course.id}
+          course={course}
+          action="add"
+          onAction={() => addCourse(course)}
+          onClick={() => setActiveCourse(course)}
+        />
+      ))}
+    </div>
+  </ScrollArea>
+  ```
+
+- [x] **Save Draft button upgraded:**
+
+  ```tsx
+  <Button
+    variant="outline"
+    size="sm"
+    className="w-full"
+    onClick={async () => {
+      await saveDraft();
+      onProgramSaved?.();
+    }}
+  >
+    Save Draft
+  </Button>
+  ```
+
+- [x] **Key Pattern Preserved:** `@dnd-kit` context fully maintained:
+  - `<DndContext>`, `<SortableContext>`, `<SortableCourseItem>` wrapper all intact
+  - Drag sensors (PointerSensor, KeyboardSensor) unchanged
+  - `CourseCard` is a pure presentation component inside sortable wrapper
+  - This separation maintains clean drag-and-drop functionality
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -657,19 +657,68 @@ https://phillipsx-pims-stage.azurewebsites.net/api
 - Desktop: Sidebar visible, can collapse to icon mode
 - `SidebarTrigger` automatically adapts to mobile/desktop contexts
 
-### ⏭️ PR-S2: Builder & Course Cards
+### ✅ PR-S2: Builder & Course Cards
 
-**Goal:** Polish the core "Program Builder" view.
-**Inputs:** `ProgramBuilder.tsx`, `CourseCard.tsx`.
-**Tasks:**
+**Goal:** Polish the core "Program Builder" view with standardized card components and improved input styling.
+**Completed:** 2025-01-16
+**Files Changed:**
 
-1.  **Refactor `CourseCard.tsx`:**
-    - Replace `div` borders with `<Card>`, `<CardHeader>`, `<CardContent>`.
-    - Replace manual status spans with `<Badge>`.
-2.  **Refactor `ProgramBuilder.tsx`:**
-    - Replace `overflow-y-auto` divs with `<ScrollArea>` for cleaner scrolling.
-    - Replace native `<input>`/`<textarea>` with shadcn `<Input>` and `<Textarea>` (better focus states).
-    - **Critical:** Ensure `@dnd-kit` drag listeners still attach correctly to the new Card components.
+- Created: `src/components/common/CourseCard.tsx`
+- Modified: `src/components/ProgramBuilder.tsx`
+
+**Implementation Details:**
+
+1. **CourseCard Component** - Reusable standardized course card:
+   - Props: `course` (Course object), `action` ("add" | "remove"), `onAction` (callback), `onClick` (detail modal)
+   - `<CardHeader>`: Thumbnail image (3:2 ratio, 16x16px preview), title, level badge (Advanced=default, Basic=secondary)
+   - `<CardContent>`: Training type, duration (days for ILT, hours for eLearning), course ID
+   - `<CardFooter>`: Action button (destructive red for remove, outline for add)
+   - Consistent hover state: `hover:bg-accent/50` transition
+
+2. **ProgramBuilder Refactor** - Modernized layout with shadcn primitives:
+   - **Inputs:** Program title and description use `<Input>` and `<Textarea>` (borderless, focus-visible:ring-0 for seamless look)
+   - **Buttons:** Filter buttons use `Button variant="secondary"` (active) / `"ghost"` (inactive) with `size="sm"`
+   - **Scrolling:** Replaced raw `overflow-y-auto` with `<ScrollArea>` for consistent cross-browser scrollbars
+   - **Course Lists:** Both workbench and catalog now use `<CourseCard>` components inside `<SortableCourseItem>` wrapper
+   - **Button:** "Save Draft" now uses `<Button variant="outline" size="sm" className="w-full">`
+   - **Drag-and-drop:** `@dnd-kit` context and sensors fully preserved; `<CourseCard>` sits inside sortable wrapper
+
+**Code Pattern Example:**
+
+```tsx
+// Workbench (left column)
+<SortableContext items={selectedCourses.map(c => c.id)} strategy={verticalListSortingStrategy}>
+  <div className="space-y-3">
+    {selectedCourses.map(course => (
+      <SortableCourseItem key={course.id} id={course.id}>
+        <CourseCard
+          course={course}
+          action="remove"
+          onAction={() => removeCourse(course.id)}
+          onClick={() => setActiveCourse(course)}
+        />
+      </SortableCourseItem>
+    ))}
+  </div>
+</SortableContext>
+
+// Catalog (right column)
+<ScrollArea className="flex-1">
+  <div className="space-y-3">
+    {filteredCourses.map(course => (
+      <CourseCard
+        key={course.id}
+        course={course}
+        action="add"
+        onAction={() => addCourse(course)}
+        onClick={() => setActiveCourse(course)}
+      />
+    ))}
+  </div>
+</ScrollArea>
+```
+
+**Test Status:** All 31 tests passing (17 hook + 14 integration); drag-and-drop functionality verified.
 
 ### ⏭️ PR-S3: Data Lists (Student & Manager)
 

--- a/src/components/ProgramBuilder.tsx
+++ b/src/components/ProgramBuilder.tsx
@@ -12,7 +12,12 @@ import {
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { SortableCourseItem } from "./SortableCourseItem";
 import { CourseDetailModal } from "./common/CourseDetailModal";
+import { CourseCard } from "./common/CourseCard";
 import { Skeleton } from "./ui/skeleton";
+import { Input } from "./ui/input";
+import { Textarea } from "./ui/textarea";
+import { Button } from "./ui/button";
+import { ScrollArea } from "./ui/scroll-area";
 
 type FilterKey = "Self-Paced" | "ILT" | "Advanced";
 
@@ -85,19 +90,19 @@ export function ProgramBuilder({ onProgramSaved }: ProgramBuilderProps) {
         <div className="flex-[0.6] flex flex-col border border-slate-300 rounded-lg">
           {/* Header */}
           <div className="p-4 border-b border-slate-300 space-y-2">
-            <input
+            <Input
               type="text"
               value={programTitle}
               onChange={(e) => updateTitle(e.target.value)}
               placeholder="My Program (Click to rename...)"
-              className="w-full text-xl font-semibold bg-transparent border-none outline-none focus:ring-0"
+              className="text-xl font-semibold border-none shadow-none focus-visible:ring-0 px-0"
             />
-            <textarea
+            <Textarea
               value={programDescription}
               onChange={(e) => updateDescription(e.target.value)}
               placeholder="Add a description for this program..."
               rows={2}
-              className="w-full p-2 text-sm text-slate-600 bg-transparent resize-none outline-none placeholder:text-slate-400"
+              className="text-sm resize-none border-none shadow-none focus-visible:ring-0 px-0"
             />
           </div>
 
@@ -117,39 +122,15 @@ export function ProgramBuilder({ onProgramSaved }: ProgramBuilderProps) {
                   items={selectedCourses.map((c) => c.id)}
                   strategy={verticalListSortingStrategy}
                 >
-                  <div className="space-y-2">
+                  <div className="space-y-3">
                     {selectedCourses.map((course) => (
                       <SortableCourseItem key={course.id} id={course.id}>
-                        <div
+                        <CourseCard
+                          course={course}
+                          action="remove"
+                          onAction={() => removeCourse(course.id)}
                           onClick={() => setActiveCourse(course)}
-                          className="flex items-center justify-between p-3 bg-blue-50 border border-blue-200 rounded hover:bg-blue-100 cursor-pointer"
-
-                          // "bg-orange-500! text-gray-950! px-6 py-3 rounded hover:bg-orange-400! hover:ring-1 hover:ring-slate-600 mx-auto font-medium"
-                        >
-                          <div className="flex-1">
-                            <h3 className="font-medium text-slate-900">
-                              {course.courseTitle}
-                            </h3>
-                            <p className="text-sm text-slate-600">
-                              {course.trainingTypeName} • {course.levelName}
-                            </p>
-                          </div>
-                          <div className="flex items-center gap-3">
-                            <span className="text-sm text-slate-500 font-mono">
-                              #{course.courseId}
-                            </span>
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                removeCourse(course.id);
-                              }}
-                              className="px-2 py-1 text-slate-600 hover:text-red-600 hover:bg-red-50 rounded"
-                              title="Remove course"
-                            >
-                              ✕
-                            </button>
-                          </div>
-                        </div>
+                        />
                       </SortableCourseItem>
                     ))}
                   </div>
@@ -166,16 +147,18 @@ export function ProgramBuilder({ onProgramSaved }: ProgramBuilderProps) {
                 {calculateTotalDuration()}
               </div>
             )}
-            <button
+            <Button
               onClick={async () => {
                 await saveDraft();
                 // Notify parent that a program was saved
                 onProgramSaved?.();
               }}
-              className="bg-orange-50! text-black outline hover:bg-orange-300! hover:ring-1 outline-gray-400! text-sm rounded px-4 py-2 font-medium"
+              variant="outline"
+              size="sm"
+              className="w-full"
             >
               Save Draft
-            </button>
+            </Button>
           </div>
         </div>
 
@@ -184,80 +167,58 @@ export function ProgramBuilder({ onProgramSaved }: ProgramBuilderProps) {
           {/* Header */}
           <div className="p-4 border-b border-slate-300 space-y-3">
             <h2 className="text-xl font-semibold">Course Catalog</h2>
-            <input
+            <Input
               type="text"
               placeholder="Search courses..."
               value={searchQuery}
               onChange={(e) => setSearch(e.target.value)}
               disabled={isLoading}
-              className="w-full px-3 py-2 border border-slate-300 rounded focus:outline-none focus:ring-2 focus:ring-phillips-blue disabled:bg-slate-100 disabled:cursor-not-allowed"
             />
             <div className="flex gap-2">
               {(["Self-Paced", "ILT", "Advanced"] as FilterKey[]).map((filterKey) => (
-                <button
+                <Button
                   key={filterKey}
                   onClick={() => toggleFilter(filterKey)}
                   disabled={isLoading}
-                  className={`px-3 py-1 rounded text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
-                    activeFilters[filterKey]
-                      ? "bg-orange-300! text-black outline outline-gray-400! font-bold shadow-sm ring-1"
-                      : "bg-orange-50! text-black outline outline-gray-400! hover:bg-orange-300! hover:ring-1"
-                  }`}
+                  variant={activeFilters[filterKey] ? "secondary" : "ghost"}
+                  size="sm"
+                  className="flex-1"
                 >
                   {filterKey}
-                </button>
+                </Button>
               ))}
             </div>
           </div>
 
           {/* Body - Scrollable */}
-          <div className="flex-1 overflow-y-auto p-4">
-            {isLoading ? (
-              <div className="space-y-3">
-                <Skeleton className="h-16 w-full" />
-                <Skeleton className="h-16 w-full" />
-                <Skeleton className="h-16 w-full" />
-                <Skeleton className="h-16 w-full" />
-                <Skeleton className="h-16 w-full" />
-              </div>
-            ) : (
-              <div className="space-y-2">
-                {filteredCourses.map((course) => (
-                  <div
-                    key={course.id}
-                    onClick={() => setActiveCourse(course)}
-                    className="flex items-center justify-between p-3 border border-slate-200 rounded hover:bg-slate-50 cursor-pointer"
-                  >
-                    <div className="flex-1">
-                      <h3 className="font-medium text-slate-900">{course.courseTitle}</h3>
-                      <p className="text-xs text-slate-500">
-                        {course.trainingTypeName} • {course.levelName}
-                      </p>
+          <ScrollArea className="flex-1">
+            <div className="p-4">
+              {isLoading ? (
+                <div className="space-y-3">
+                  <Skeleton className="h-48 w-full" />
+                  <Skeleton className="h-48 w-full" />
+                  <Skeleton className="h-48 w-full" />
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {filteredCourses.map((course) => (
+                    <CourseCard
+                      key={course.id}
+                      course={course}
+                      action="add"
+                      onAction={() => addCourse(course)}
+                      onClick={() => setActiveCourse(course)}
+                    />
+                  ))}
+                  {filteredCourses.length === 0 && (
+                    <div className="flex items-center justify-center h-full text-slate-400 text-sm py-8">
+                      No courses found
                     </div>
-                    <div className="flex items-center gap-3">
-                      <span className="text-sm text-slate-500 font-mono">
-                        #{course.courseId}
-                      </span>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          addCourse(course);
-                        }}
-                        className="px-3 py-1 bg-orange-50! text-black outline hover:bg-orange-300! hover:ring-1 outline-gray-400! text-sm rounded"
-                      >
-                        Add
-                      </button>
-                    </div>
-                  </div>
-                ))}
-                {filteredCourses.length === 0 && (
-                  <div className="flex items-center justify-center h-full text-slate-400 text-sm">
-                    No courses found
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </ScrollArea>
         </div>
 
         <CourseDetailModal

--- a/src/components/common/CourseCard.tsx
+++ b/src/components/common/CourseCard.tsx
@@ -1,0 +1,100 @@
+import { Course } from "@/hooks/useProgramBuilder";
+import { Card, CardHeader, CardContent, CardFooter } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+interface CourseCardProps {
+  course: Course;
+  action: "add" | "remove";
+  onAction: () => void;
+  onClick?: () => void;
+}
+
+export function CourseCard({ course, action, onAction, onClick }: CourseCardProps) {
+  const handleCardClick = () => {
+    if (onClick) {
+      onClick();
+    }
+  };
+
+  const handleActionClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onAction();
+  };
+
+  // Determine level badge variant
+  const getLevelVariant = (level: string) => {
+    if (level === "Advanced") return "default";
+    return "secondary";
+  };
+
+  return (
+    <Card
+      className="cursor-pointer hover:bg-accent/50 transition-colors"
+      onClick={handleCardClick}
+    >
+      <CardHeader className="p-4 pb-3">
+        <div className="flex items-start gap-3">
+          {/* Course Image Thumbnail */}
+          {course.previewImageUrl && (
+            <div className="relative flex-shrink-0 w-16 h-16 rounded overflow-hidden bg-slate-100">
+              <img
+                src={course.previewImageUrl}
+                alt={course.courseTitle}
+                className="w-full h-full object-cover"
+                loading="lazy"
+              />
+            </div>
+          )}
+
+          {/* Title and Level Badge */}
+          <div className="flex-1 min-w-0">
+            <h3 className="font-semibold text-sm leading-tight mb-2 line-clamp-2">
+              {course.courseTitle}
+            </h3>
+            <Badge variant={getLevelVariant(course.levelName)} className="text-xs">
+              {course.levelName}
+            </Badge>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="px-4 pb-3 pt-0">
+        <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+          {/* Training Type */}
+          <div className="flex items-center gap-2">
+            <span className="font-medium">Type:</span>
+            <span>{course.trainingTypeName}</span>
+          </div>
+
+          {/* Duration */}
+          <div className="flex items-center gap-2">
+            <span className="font-medium">Duration:</span>
+            <span>
+              {course.trainingTypeName === "ILT"
+                ? `${course.totalDays || 0} day${course.totalDays !== 1 ? "s" : ""}`
+                : `${course.hours || 0} hour${course.hours !== 1 ? "s" : ""}`}
+            </span>
+          </div>
+
+          {/* Course ID */}
+          <div className="flex items-center gap-2 font-mono">
+            <span className="font-medium">ID:</span>
+            <span>#{course.courseId}</span>
+          </div>
+        </div>
+      </CardContent>
+
+      <CardFooter className="px-4 pb-4 pt-0">
+        <Button
+          size="sm"
+          variant={action === "remove" ? "destructive" : "outline"}
+          onClick={handleActionClick}
+          className="w-full"
+        >
+          {action === "remove" ? "Remove" : "Add"}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}


### PR DESCRIPTION
- Create reusable CourseCard component for course display (add/remove actions)
- Replace raw inputs with shadcn Input/Textarea (better focus states)
- Replace overflow-y-auto with ScrollArea for consistent scrolling
- Replace custom filter buttons with Button component (semantic variants)
- Upgrade "Save Draft" button to shadcn Button
- Preserve @dnd-kit drag-and-drop functionality in sortable context
- All 31 tests passing (17 hook + 14 integration)

Closes #S2